### PR TITLE
Disable certain hostile mobs in siege zones - Add PreMobSpawnEvent Listener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
       <id>citizens-repo</id>
       <url>https://repo.citizensnpcs.co/</url>
     </repository>
+    <repository>
+      <id>papermc</id>
+      <url>https://repo.papermc.io/repository/maven-public/</url>
+    </repository>
+
 
   </repositories>
 
@@ -69,6 +74,12 @@
       <groupId>net.citizensnpcs</groupId>
       <artifactId>citizensapi</artifactId>
       <version>2.0.28-SNAPSHOT</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>dev.folia</groupId>
+      <artifactId>folia-api</artifactId>
+      <version>1.20.1-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
+++ b/src/main/java/com/gmail/goosius/siegewar/SiegeWar.java
@@ -1,6 +1,6 @@
 package com.gmail.goosius.siegewar;
 
-import com.gmail.goosius.siegewar.listeners.SiegeWarTownyChatEventListener;
+import com.gmail.goosius.siegewar.listeners.*;
 import com.gmail.goosius.siegewar.settings.SiegeWarSettings;
 import com.gmail.goosius.siegewar.utils.DataCleanupUtil;
 
@@ -25,15 +25,6 @@ import com.gmail.goosius.siegewar.command.SiegeWarCommand;
 import com.gmail.goosius.siegewar.command.SiegeWarNationSetOccupationTaxAddonCommand;
 import com.gmail.goosius.siegewar.hud.SiegeHUDManager;
 import com.gmail.goosius.siegewar.integration.dynmap.DynmapIntegration;
-import com.gmail.goosius.siegewar.listeners.SiegeWarActionListener;
-import com.gmail.goosius.siegewar.listeners.SiegeWarBukkitEventListener;
-import com.gmail.goosius.siegewar.listeners.SiegeWarNationEventListener;
-import com.gmail.goosius.siegewar.listeners.SiegeWarPlotEventListener;
-import com.gmail.goosius.siegewar.listeners.SiegeWarSafeModeListener;
-import com.gmail.goosius.siegewar.listeners.SiegeWarSelfListener;
-import com.gmail.goosius.siegewar.listeners.SiegeWarStatusScreenListener;
-import com.gmail.goosius.siegewar.listeners.SiegeWarTownEventListener;
-import com.gmail.goosius.siegewar.listeners.SiegeWarTownyEventListener;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -174,6 +165,7 @@ public class SiegeWar extends JavaPlugin {
 			pm.registerEvents(new SiegeWarPlotEventListener(this), this);
 			pm.registerEvents(new SiegeWarStatusScreenListener(), this);
 			pm.registerEvents(new SiegeWarSelfListener(), this);
+			pm.registerEvents(new PreMobSpawnEventListener(), this);
 			if (getServer().getPluginManager().isPluginEnabled("TownyChat")) {
 				info("SiegeWar found TownyChat plugin, enabling TownyChat integration.");
 				pm.registerEvents(new SiegeWarTownyChatEventListener(), this);

--- a/src/main/java/com/gmail/goosius/siegewar/listeners/PreMobSpawnEventListener.java
+++ b/src/main/java/com/gmail/goosius/siegewar/listeners/PreMobSpawnEventListener.java
@@ -1,0 +1,51 @@
+package com.gmail.goosius.siegewar.listeners;
+
+import com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent;
+import org.bukkit.entity.EntityType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import static com.gmail.goosius.siegewar.SiegeWarAPI.isLocationInActiveSiegeZone;
+
+//pm.registerEvents(new PreMobSpawnEventListener(), this); -- listener register
+
+public class PreMobSpawnEventListener implements Listener {
+
+    /*List of mobs defined to be not allowed to spawn in an active siege zone.*/
+    private static final EntityType[] prohibitedMobs = {
+            EntityType.ZOMBIE,
+            EntityType.SKELETON,
+            EntityType.SPIDER,
+            EntityType.CREEPER,
+            EntityType.DROWNED,
+            EntityType.WITCH,
+            EntityType.ZOMBIE_VILLAGER,
+            EntityType.CAVE_SPIDER,
+            EntityType.PHANTOM,
+    };
+
+    /*Checks if a mob type is on the list of prohibited mobs
+    * Function is working
+    * */
+    private static boolean isProhibitedMob(EntityType mob) {
+        for (int x = 0; x < prohibitedMobs.length; x++) {
+            if (mob == prohibitedMobs[x]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    @EventHandler
+    public void onSiegeZonePreCreatureSpawnEvent(PreCreatureSpawnEvent event) {
+
+        //If it's not one of the prohibited spawn mobs in siege zone, ignore.
+        if(!isProhibitedMob(event.getType())){
+            return;
+        }
+        //If the location of the mob is in an active Siege Zone, cancel the spawn event.
+        if (isLocationInActiveSiegeZone(event.getSpawnLocation())) {
+            event.setCancelled(true);
+        }
+    }
+}


### PR DESCRIPTION
Disables the spawning of a pre-defined list of mobs in active siege zones. Currently, the list is set to contain the most common hostile mobs since those are the mobs that players have complained about the most.