### PR TITLE
Biweekly Sieges Feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.gmail.goosius</groupId>
   <artifactId>SiegeWar</artifactId>
-  <version>2.18.0-EarthPolFork</version>
+  <version>2.18.0-EarthPolFork-featurebiweeklyTEST</version>
   <name>siegewar</name> <!-- Leave lower-cased -->
 
   <properties>

--- a/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
+++ b/src/main/java/com/gmail/goosius/siegewar/command/SiegeWarCommand.java
@@ -161,18 +161,21 @@ public class SiegeWarCommand implements CommandExecutor, TabCompleter {
 
 	private void parseSiegeWarNextSessionCommand(Player player) {
 		BattleSession session = BattleSession.getBattleSession();
-		if (session.isActive())
+		if (session.isActive()) {
 			Messaging.sendMsg(player, Translatable.of("msg_session_is_active_now"));
-		else {
-			Translatable message = Translatable.of("msg_next_session_cannot_be_determined");
-			if (session.getScheduledStartTime() != null) {
-				long timeRemaining = session.getScheduledStartTime() - System.currentTimeMillis(); 
-				message = Translatable.of("msg_next_siege_session_in_minutes", TimeMgmt.getFormattedTimeValue(timeRemaining));
+		} else {
+			// Check if a scheduled start time exists.
+			if (session.getScheduledStartTime() == null) {
+				// When no start time is set, tell the player there are no sieges this week.
+				Messaging.sendMsg(player, Translatable.of("msg_no_sieges_this_week"));
+			} else {
+				long timeRemaining = session.getScheduledStartTime() - System.currentTimeMillis();
+				Translatable message = Translatable.of("msg_next_siege_session_in_minutes", TimeMgmt.getFormattedTimeValue(timeRemaining));
+				Messaging.sendMsg(player, message);
 			}
-			Messaging.sendMsg(player, message);
 		}
-		
 	}
+
 
 	private void parseSiegeWarCollectCommand(Player player) {
 		if(!TownyEconomyHandler.isActive())

--- a/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/ConfigNodes.java
@@ -1238,7 +1238,29 @@ public enum ConfigNodes {
 			"# If this value is true, then the Siege Lore feature is enabled.",
 			"# When a banner is broken after a siege has ended, it will drop with a name and lore set to display info about the siege.",
 			"# Banners dropped from this feature can be placed and broken without losing lore, but can not be used to begin a new siege.",
-			"# Shields can be crafted from the lore banners and will inherit the lore and name from the banner.");
+			"# Shields can be crafted from the lore banners and will inherit the lore and name from the banner."),
+
+
+	// ==== EARTHPOL CUSTOM SETTINGS ====
+
+	BATTLE_SESSION_SCHEDULER_BIWEEKLY_ENABLED(
+			"battle_session_scheduler.biweekly_enabled",
+			"false",
+			"# EARTHPOL CUSTOM: If true, battle sessions will be scheduled on a biweekly basis (every other week)."
+	),
+	BATTLE_SESSION_SCHEDULER_BIWEEKLY_PARITY(
+			"battle_session_scheduler.biweekly_parity",
+			"even",
+			"# EARTHPOL CUSTOM: Determines the week parity in which battle sessions occur.",
+			"# Use 'even' for even-numbered weeks or 'odd' for odd-numbered weeks."
+	);
+
+
+
+
+
+
+
 	private final String Root;
 	private final String Default;
 	private String[] comments;

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -661,4 +661,19 @@ public class SiegeWarSettings {
 	public static String getDynmapLayerName() {
 		return Settings.getString(ConfigNodes.WAR_SIEGE_DYNMAP_LAYER_NAME);
 	}
+
+	// ======  EARTHPOL FORK SPECIFIC SETTINGS ======
+
+	public static boolean isBattleSessionBiweeklyEnabled() {
+		// Reads from the config using a key defined in ConfigNodes.
+		// Make sure you define ConfigNodes.BATTLE_SESSION_SCHEDULER_BIWEEKLY_ENABLED (or similar) to match "battle_session_scheduler.biweekly_enabled"
+		return Settings.getBoolean(ConfigNodes.BATTLE_SESSION_SCHEDULER_BIWEEKLY_ENABLED);
+	}
+
+	public static String getBattleSessionBiweeklyParity() {
+		// Reads the parity setting ("even" or "odd") from config.
+		// Again, define ConfigNodes.BATTLE_SESSION_SCHEDULER_BIWEEKLY_PARITY to match "battle_session_scheduler.biweekly_parity"
+		return Settings.getString(ConfigNodes.BATTLE_SESSION_SCHEDULER_BIWEEKLY_PARITY);
+	}
+
 }

--- a/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
+++ b/src/main/java/com/gmail/goosius/siegewar/settings/SiegeWarSettings.java
@@ -433,7 +433,7 @@ public class SiegeWarSettings {
 		return nextSession;
 	}
 
-	private static List<LocalDateTime> getAllBattleSessionStartTimesForDay(LocalDate day) {
+	public static List<LocalDateTime> getAllBattleSessionStartTimesForDay(LocalDate day) {
 		//Get Start times for the given day
 		String startTimesAsString = "";
 		switch (day.getDayOfWeek()) {

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarBattleSessionUtil.java
@@ -23,10 +23,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffectType;
 
 import java.time.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.time.temporal.WeekFields;
+import java.util.*;
 
 public class SiegeWarBattleSessionUtil {
 	
@@ -351,27 +349,71 @@ public class SiegeWarBattleSessionUtil {
 		LocalDateTime currentTime = LocalDateTime.now();
 		LocalDateTime nextStartDateTime = null;
 
-		//Look for next configured-start-time for today
-		for (LocalDateTime candidateStartTime : SiegeWarSettings.getAllBattleSessionStartTimesForToday()) {
-			if(candidateStartTime.isAfter(currentTime)) {
+		// Retrieve today's candidate start times.
+		List<LocalDateTime> todayCandidateTimes = SiegeWarSettings.getAllBattleSessionStartTimesForToday();
+
+		// Check if biweekly scheduling is enabled.
+		boolean biweeklyEnabled = SiegeWarSettings.isBattleSessionBiweeklyEnabled();
+		// Retrieve the desired parity, e.g. "even" or "odd" (default "even" if not configured)
+		String parity = SiegeWarSettings.getBattleSessionBiweeklyParity().toLowerCase(Locale.getDefault());
+		// Prepare WeekFields to calculate week numbers from dates.
+		WeekFields weekFields = WeekFields.of(Locale.getDefault());
+
+		// Look for the next configured start time for today.
+		for (LocalDateTime candidateStartTime : todayCandidateTimes) {
+			// If biweekly is enabled, filter based on week parity.
+			if (biweeklyEnabled) {
+				int candidateWeek = candidateStartTime.get(weekFields.weekOfWeekBasedYear());
+				// For "even" parity, skip odd-numbered weeks.
+				if ("even".equals(parity) && candidateWeek % 2 != 0) {
+					continue;
+				}
+				// For "odd" parity, skip even-numbered weeks.
+				if ("odd".equals(parity) && candidateWeek % 2 == 0) {
+					continue;
+				}
+			}
+			if (candidateStartTime.isAfter(currentTime)) {
 				nextStartDateTime = candidateStartTime;
 				break;
 			}
 		}
 
-		//If no configured-start-time was found, look for the first configured time for the rest of the week.
-		if(nextStartDateTime == null) {
+		// If no suitable candidate was found for today, look for a candidate from future days.
+		if (nextStartDateTime == null) {
 			nextStartDateTime = SiegeWarSettings.getNextBattleSessionDaysInAdvance();
+			// If biweekly filtering is enabled, make sure the candidate from a future day also matches the parity.
+			while (nextStartDateTime != null && biweeklyEnabled) {
+				int candidateWeek = nextStartDateTime.get(weekFields.weekOfWeekBasedYear());
+				if (("even".equals(parity) && candidateWeek % 2 != 0)
+						|| ("odd".equals(parity) && candidateWeek % 2 == 0)) {
+					// Candidate does not match parity; fetch the next candidate day.
+					nextStartDateTime = getNextCandidateFromNextDay(nextStartDateTime);
+				} else {
+					break;
+				}
+			}
 		}
 
-		//If nextStartTime is still null, return null, else return the UTC time in millis of the given value.
-		if(nextStartDateTime != null) {
+		// If a valid start time was determined, convert it to UTC epoch millis.
+		if (nextStartDateTime != null) {
 			ZonedDateTime nextStartTimeInServerTimeZone = ZonedDateTime.of(nextStartDateTime, ZoneId.systemDefault());
 			ZonedDateTime nextStartTimeInUtcTimeZone = nextStartTimeInServerTimeZone.withZoneSameInstant(ZoneId.of("UTC"));
 			return nextStartTimeInUtcTimeZone.toInstant().toEpochMilli();
 		} else {
 			return null;
 		}
+	}
+
+	/**
+	 * Helper method to fetch a candidate start time from the day following the provided candidate.
+	 * This method retrieves all candidate start times for the day after the candidate's date and returns
+	 * the first candidate if available, or null otherwise.
+	 */
+	private static LocalDateTime getNextCandidateFromNextDay(LocalDateTime currentCandidate) {
+		LocalDate nextDay = currentCandidate.toLocalDate().plusDays(1);
+		List<LocalDateTime> candidateTimes = SiegeWarSettings.getAllBattleSessionStartTimesForDay(nextDay);
+		return candidateTimes.isEmpty() ? null : candidateTimes.get(0);
 	}
 
 }

--- a/src/main/resources/lang/en-US.yml
+++ b/src/main/resources/lang/en-US.yml
@@ -723,3 +723,6 @@ msg_err_town_already_invaded_only_one_action: "&cYou cannot plunder an already i
 
 siege_msg_err_cannot_assign_rank_during_active_battlesession: "&cYou cannot add the %s rank while the battle session is active."
 siege_msg_err_cannot_assign_rank_during_active_siege: "&cYou cannot add the %s rank while your town is involved in a siege."
+
+# EarthPol Custom Messages
+msg_no_sieges_this_week: "There will be no sieges this week. Check back next week."


### PR DESCRIPTION
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
Add the ability for Sieges to occur on a biweekly basis. They can occur on the first and third week of the month or second and fourth week of the month.

Players will be notified that there are no sieges this week if checking /sw nextsession. The week is considered starting on Monday and ending on Sunday.

Config nodes were added to be able to toggle this on or off.

Tested this in the server, and the plugin loads correctly. Changing the biweekly parity option has the expected behavior.

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


BATTLE_SESSION_SCHEDULER_BIWEEKLY_ENABLED(
			"battle_session_scheduler.biweekly_enabled",
			"false",
			"# EARTHPOL CUSTOM: If true, battle sessions will be scheduled on a biweekly basis (every other week)."
	),
	BATTLE_SESSION_SCHEDULER_BIWEEKLY_PARITY(
			"battle_session_scheduler.biweekly_parity",
			"even",
			"# EARTHPOL CUSTOM: Determines the week parity in which battle sessions occur.",
			"# Use 'even' for even-numbered weeks or 'odd' for odd-numbered weeks."
	);

____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ X ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->
