### PR TITLE
Disable distance check for conquest sieges

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/playeractions/StartConquestSiege.java
+++ b/src/main/java/com/gmail/goosius/siegewar/playeractions/StartConquestSiege.java
@@ -72,9 +72,13 @@ public class StartConquestSiege {
 				throw new TownyException(translator.of("msg_err_siege_war_cannot_attack_non_enemy_nation"));
 		}
 
+		// EARTHPOL CUSTOM CHANGE: Disable distance from capital check for conquest sieges.
+		// This checks the values under the "proximity:" section of the Towny config.
+		/*
 		SiegeWarDistanceUtil.throwIfTownIsTooFarFromNationCapitalByWorld(nationOfSiegeStarter, targetTown);
 
 		SiegeWarDistanceUtil.throwIfTownIsTooFarFromNationCapitalByDistance(nationOfSiegeStarter, targetTown);
+		 */
 
 		SiegeWarNationUtil.throwIfNationHasTooManyTowns(nationOfSiegeStarter);
 	}


### PR DESCRIPTION
This disables the distance restriction when initiating a conquest siege.