### PR TITLE
feat: make every siege related message prefixed with [SiegeWar]

### DIFF
--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMessageUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarMessageUtil.java
@@ -1,0 +1,42 @@
+package com.gmail.goosius.siegewar.utils;
+
+import com.gmail.goosius.siegewar.SiegeWar;
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.object.Nation;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.Translatable;
+import com.palmergames.bukkit.util.Colors;
+import com.palmergames.util.StringMgmt;
+import org.bukkit.entity.Player;
+
+import static com.palmergames.bukkit.towny.TownyMessaging.sendMessage;
+
+public class SiegeWarMessageUtil {
+    /**
+     * Send a message to All online residents of a nation and log
+     * preceded by the [NationName], translated for the end-user.
+     *
+     * @param nation Nation to pass the message to, prefix message with.
+     * @param message Translatable object to be messaged to the player using their locale.
+     */
+    public static void sendPrefixedNationMessage(Nation nation, Translatable message) {
+        SiegeWar.info(Colors.strip("[Nation Msg] " + StringMgmt.remUnderscore(nation.getName()) + ": " + message.translate()));
+
+        for (Player player : TownyAPI.getInstance().getOnlinePlayers(nation))
+            sendMessage(player, Translatable.of("siegewar_plugin_prefix", StringMgmt.remUnderscore(nation.getName())).append(message));
+    }
+
+    /**
+     * Send a message to All online residents of a town and log
+     * preceded by the [Townname], translated for the end-user.
+     *
+     * @param town Town to pass the message to, and prefix message with.
+     * @param message Translatable object to be messaged to the player using their locale.
+     */
+    public static void sendPrefixedTownMessage(Town town, Translatable message) {
+        SiegeWar.info(Colors.strip("[Town Msg] " + StringMgmt.remUnderscore(town.getName()) + ": " + message.translate()));
+
+        for (Player player : TownyAPI.getInstance().getOnlinePlayers(town))
+            sendMessage(player, Translatable.of("siegewar_plugin_prefix", StringMgmt.remUnderscore(town.getName())).append(message));
+    }
+}

--- a/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
+++ b/src/main/java/com/gmail/goosius/siegewar/utils/SiegeWarNotificationUtil.java
@@ -116,12 +116,12 @@ public class SiegeWarNotificationUtil {
 			for(Nation nationToInform: nationsToInform) {
 				for (Translatable line : message) 
 					if (line != null)
-						TownyMessaging.sendPrefixedNationMessage(nationToInform, line);
+						SiegeWarMessageUtil.sendPrefixedNationMessage(nationToInform, line);
 			}
 			for(Town townToInform: townsToInform) {
 				for (Translatable line : message)
 					if (line != null)
-						TownyMessaging.sendPrefixedTownMessage(townToInform, line);
+						SiegeWarMessageUtil.sendPrefixedTownMessage(townToInform, line);
 			}
 
 		} catch (Exception e) {


### PR DESCRIPTION
<!--- Welcome! It looks like you're opening a pull request for the Towny project, we think that's great. This form is pre-populated with a Contributor License Agreement, which is required if you want to contribute your code. It is there to protect your copyright over the code but also to protect Towny, making your code available to us to use indefinitely. --->
#### Description: 
<!--- Describe your Pull Request's purpose here please. --->
makes the siegewar siege notifications (defender/attacker deaths, etc) prefixed with [SiegeWar] for easy filtering for a future mod

____
#### New Nodes/Commands/ConfigOptions: 
<!--- If your PR includes any new permission nodes, commands or config options list them here. --->


____
#### Relevant Issue ticket:
<!--- If your pull request addresses an Issue ticket please provide the link to that --->


____
- [ ] I have tested this pull request for defects on a server. 
<!--- Place x between [ ] if you have tested this code on a server. --->

By making this pull request, I represent that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the TownyAdvanced organization has the copyright to use and modify my contribution under the SiegeWar [License](https://github.com/TownyAdvanced/SiegeWar/blob/master/LICENSE.md) for perpetuity.

NEEDS TESTING!!!!!
